### PR TITLE
Include whole object

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ function plugin(opts) {
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
         file[name] = included[filename];
-        file[name].contents = marked( String(included[filename].contents));
-        file[name].sourcefile = filename; 
+        file[name].contents = included[filename].contents;
+        file[name].sourcefile = filename;
         done();
       }
     }

--- a/index.js
+++ b/index.js
@@ -64,8 +64,7 @@ function plugin(opts) {
 
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
-        var fileClone = included[filename];
-        file[name] = fileClone;
+        file[name] = clone(included[filename]);
         file[name].contents = included[filename].contents;
         done();
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ function plugin(opts) {
         var fileClone = included[filename];
         file[name] = fileClone;
         file[name].contents = included[filename].contents;
-        file[name].sourcefile = filename;
         done();
 
       }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var debug = require('debug')('metalsmith-include');
+var clone = require('clone');
 var each = require('async').each;
 
 /**
@@ -63,10 +64,12 @@ function plugin(opts) {
 
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
-        file[name] = included[filename];
+        var fileClone = included[filename];
+        file[name] = fileClone;
         file[name].contents = included[filename].contents;
         file[name].sourcefile = filename;
         done();
+
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function plugin(opts) {
 
         file[name] = included[filename];
         file[name].contents = marked( String(included[filename].contents));
-
+        file[name].sourcefile = filename; 
         done();
       }
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 
 var debug = require('debug')('metalsmith-include');
 var each = require('async').each;
+var marked = require('marked');
 
 /**
  * Expose `plugin`.
@@ -63,7 +64,7 @@ function plugin(opts) {
 
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
-        file[name] = included[filename].contents;
+        file[name] = marked(String(included[filename].contents));
 
         done();
       }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 
 var debug = require('debug')('metalsmith-include');
 var each = require('async').each;
-var marked = require('marked');
 
 /**
  * Expose `plugin`.

--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ function plugin(opts) {
 
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
-        file[name] = marked(String(included[filename].contents));
+        file[name] = included[filename];
+        file[name].contents = marked( String(included[filename].contents));
 
         done();
       }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "dependencies": {
     "async": "^0.7.0",
-    "clone": "^1.0.2",
-    "debug": "^0.8.1",
-    "merge": "^1.2.0"
+    "debug": "^0.8.1"
   },
   "devDependencies": {
     "mocha": "1.x",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "async": "^0.7.0",
+    "clone": "^1.0.2",
     "debug": "^0.8.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   },
   "dependencies": {
     "async": "^0.7.0",
+    "clone": "^1.0.2",
     "debug": "^0.8.1",
-    "marked": "^0.3.3"
+    "marked": "^0.3.3",
+    "merge": "^1.2.0"
   },
   "devDependencies": {
     "mocha": "1.x",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "test": "make test"
   },
   "dependencies": {
+    "async": "^0.7.0",
     "debug": "^0.8.1",
-    "async": "^0.7.0"
+    "marked": "^0.3.3"
   },
   "devDependencies": {
     "mocha": "1.x",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "async": "^0.7.0",
     "clone": "^1.0.2",
     "debug": "^0.8.1",
-    "marked": "^0.3.3",
     "merge": "^1.2.0"
   },
   "devDependencies": {
@@ -18,8 +17,7 @@
     "metalsmith": "0.x",
     "assert-dir-equal": "0.x",
     "metalsmith-templates": "^0.5.0",
-    "jade": "^1.3.1",
-    "metalsmith-markdown": "^0.2.1"
+    "jade": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/test/fixture-frontmatter/build/index.md
+++ b/test/fixture-frontmatter/build/index.md
@@ -1,0 +1,2 @@
+
+### Welcome to my website!

--- a/test/fixture-frontmatter/build/thanks.md
+++ b/test/fixture-frontmatter/build/thanks.md
@@ -1,0 +1,1 @@
+#### Thanks for visiting!

--- a/test/fixture-frontmatter/expected/index.md
+++ b/test/fixture-frontmatter/expected/index.md
@@ -1,0 +1,2 @@
+
+### Welcome to my website!

--- a/test/fixture-frontmatter/expected/thanks.md
+++ b/test/fixture-frontmatter/expected/thanks.md
@@ -1,0 +1,5 @@
+---
+testkey: testkey
+---
+
+#### Thanks for visiting!

--- a/test/fixture-frontmatter/src/index.md
+++ b/test/fixture-frontmatter/src/index.md
@@ -1,0 +1,6 @@
+---
+include:
+  thanks: thanks.md
+---
+
+### Welcome to my website!

--- a/test/fixture-frontmatter/src/thanks.md
+++ b/test/fixture-frontmatter/src/thanks.md
@@ -1,0 +1,5 @@
+---
+testkey: testkey
+---
+
+#### Thanks for visiting!

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('metalsmith-include', function(){
       .build(function(err, files){
         if (err) return done(err);
         equal('test/fixture-basic/expected', 'test/fixture-basic/build');
-        assert.equal(files['index.md'].thanks, files['thanks.md'].contents);
+        assert.equal(files['index.md'].thanks.contents, files['thanks.md'].contents);
         done();
       });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,16 @@ describe('metalsmith-include', function(){
       });
   });
 
+  it('should include the frontmatter of included source files', function(done){
+    Metalsmith('test/fixture-basic')
+      .use(include())
+      .build(function(err, files){
+        if (err) return done(err);
+        assert.equal(files['index.md'].thanks.testkey, files['thanks.md'].testkey);
+        done();
+      });
+  });
+
   it('should include files without an extension', function(done){
     Metalsmith('test/fixture-ext')
       .use(include())

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 var equal = require('assert-dir-equal');
 var Metalsmith = require('metalsmith');
 var templates = require('metalsmith-templates');
-var markdown = require('metalsmith-markdown');
 var include = require('..');
 
 describe('metalsmith-include', function(){


### PR DESCRIPTION
This is a 'breaking' (backwards compatability would be lost) alternative to the previous pull request.

The partial now clones the yaml frontmatter in addition to the contents.
So one would have to echo 
partialKey.contents to get the markdown contents, 
but also would gain access to partialKey.yamlFrontmatterKey

Which imho would help 'keep like with like' in certain use cases (block level links, popover/tooltip descriptions, etc.), making each partial self-contained.

Also addresses #4 
