### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 ## Example
 
 index.md:
-
+(note the lack of extension in the included filename)
 ```markdown
 ---
 template: home.jade
 include:
-  thanks: thanks.md
+  thanks: thanks
 ---
 
 ### Welcome to my website!
@@ -55,7 +55,7 @@ Output:
     $ npm install metalsmith-include
 
 ## Options
-  
+
   The only option is `deletePartials`, which tells `metalsmith-include` whether or not to remove files that are included in other files, and have a `partial` indicator in their front-matter. Defaults to true.
 
 ## CLI Usage

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 
 var debug = require('debug')('metalsmith-include');
 var each = require('async').each;
+var marked = require('marked');
 
 /**
  * Expose `plugin`.
@@ -63,7 +64,7 @@ function plugin(opts) {
 
         debug('adding %s to includes as `%s`', resolvedFilename, name);
 
-        file[name] = included[filename].contents;
+        file[name] = marked(String(included[filename].contents));
 
         done();
       }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "test": "make test"
   },
   "dependencies": {
+    "async": "^0.7.0",
     "debug": "^0.8.1",
-    "async": "^0.7.0"
+    "marked": "^0.3.3"
   },
   "devDependencies": {
     "mocha": "1.x",


### PR DESCRIPTION
Changes to readme, removing extension from included file path and adding a note.

Leaving the extension in errors out if running include after metalsmith-markdown.
